### PR TITLE
Add additional reflect.json for grpc sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ target
 .classpath
 .project
 unpack
+samples/vanilla-jpa/jpa
+samples/vanilla-orm/orm
+samples/vanilla-grpc/grpc
+samples/demo/demo
+samples/commandlinerunner/clr
+.attach_pid*

--- a/src/main/resources/reflect.json
+++ b/src/main/resources/reflect.json
@@ -1258,6 +1258,10 @@
 		"allDeclaredConstructors": true,
 		"allDeclaredMethods": true
 	},
+	{	"name": "io.netty.channel.ChannelInitializer",
+		"allDeclaredConstructors": true,
+		"allDeclaredMethods": true
+	},
 	// ^^^ vanilla-grpc
 
 	// Because of EntityTuplizerFactory


### PR DESCRIPTION
I still get errors at runtime, but logged at DEBUG, so maybe ignorable.

```
com.oracle.svm.core.util.UserError$UserException: Classes that should be initialized at run time got initialized during image building:
 io.netty.handler.codec.http2.CharSequenceMap the class was requested to be initialized at build time (from the command line).  To see why io.netty.handler.codec.http2.CharSequenceMap got initialized use -H:+TraceClassInitializationio.netty.handler.codec.http2.Http2Headers$PseudoHeaderName the class was requested to be initialized at build time (from the command line).  To see why io.netty.handler.codec.http2.Http2Headers$PseudoHeaderName got initialized use -H:+TraceClassInitialization
        at com.oracle.svm.core.util.UserError.abort(UserError.java:65)
 ...
```